### PR TITLE
Store the select index separately and use casts more

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: rust
+rust:
+  - stable
+  - beta
+  - nightly
+matrix:
+  allow_failures:
+    - rust: nightly

--- a/src/index_raw.rs
+++ b/src/index_raw.rs
@@ -334,6 +334,7 @@ fn build_inner_l1l2(l1l2_index: &mut [L1L2Entry], data_chunk: Bits<&[u8]>) -> u6
 }
 
 fn build_samples<W: OnesOrZeros>(l0_index: &[u64], l1l2_index: &[L1L2Entry], bits: Bits<&[u8]>, samples: &mut [SampleEntry]) {
+
     // TODO: Unimplemented
     unimplemented!();
 }
@@ -432,6 +433,27 @@ where F: Fn(usize) -> bool
     }
 
     return true_from;
+}
+
+/// Works like binary_search, but optimises for the sought index
+/// being near the starting point
+fn binary_search_lower<F>(from: usize, until: usize, check: F) -> usize
+where F: Fn(usize) -> bool
+{
+    if until <= from + 1 { return binary_search(from, until, check) };
+    let span = until - from;
+    let half_span = span / 2;
+    let mut offset = 1;
+    loop {
+        let test = from + offset;
+        if check(test) {
+            return binary_search(from, test, check);
+        } else if offset >= half_span {
+            return binary_search(from + offset, until, check);
+        } else {
+            offset *= 2;
+        }
+    }
 }
 
 pub fn select<W: OnesOrZeros>(index: &[u64], bits: Bits<&[u8]>, target_rank: u64) -> Option<u64> {

--- a/src/index_raw.rs
+++ b/src/index_raw.rs
@@ -135,13 +135,13 @@ mod structure {
     pub struct SampleEntry(u32);
 
     impl SampleEntry {
-        pub fn pack(idx_in_l0_block: u64) -> Self {
-            debug_assert!(idx_in_l0_block <= u32::max_value() as u64);
-            SampleEntry(idx_in_l0_block as u32)
+        pub fn pack(block_idx_in_l0_block: usize) -> Self {
+            debug_assert!(block_idx_in_l0_block <= u32::max_value() as usize);
+            SampleEntry(block_idx_in_l0_block as u32)
         }
 
-        pub fn idx_in_l0_block(self) -> u64 {
-            self.0 as u64
+        pub fn block_idx_in_l0_block(self) -> usize {
+            self.0 as usize
         }
     }
 
@@ -414,23 +414,6 @@ pub fn rank<W: OnesOrZeros>(index: &[u64], bits: Bits<&[u8]>, idx: u64) -> Optio
     rank_ones(index, bits, idx).map(|res_ones| W::convert_count(res_ones, idx))
 }
 
-fn index_within<T: Sized>(slice: &[T], item: &T) -> Option<usize> {
-    use std::mem::size_of;
-
-    if size_of::<T>() == 0 {
-        return None;
-    };
-
-    let slice_start = (slice.as_ptr() as *const T) as usize;
-    let item_pos = (item as *const T) as usize;
-    if item_pos < slice_start {
-        return None;
-    };
-
-    let idx = (item_pos - slice_start) / size_of::<T>();
-    if idx >= slice.len() { None } else { Some(idx) }
-}
-
 /// Assumes that for some i s.t. from <= i < until: check(j) <=> j >= i
 /// This returns such i.
 fn binary_search<F>(from: usize, until: usize, check: F) -> usize
@@ -492,7 +475,7 @@ pub fn select<W: OnesOrZeros>(index: &[u64], bits: Bits<&[u8]>, target_rank: u64
             // Sample is from the previous l0 block
             0
         } else {
-            (select_samples[sample_idx as usize].idx_in_l0_block() / size::BITS_PER_L2_BLOCK) as usize
+            select_samples[sample_idx as usize].block_idx_in_l0_block()
         }
     };
     let block_idx_should_be_less_than = {
@@ -505,7 +488,7 @@ pub fn select<W: OnesOrZeros>(index: &[u64], bits: Bits<&[u8]>, target_rank: u64
             // Sample does not exist
             inner_l1l2_index.len() * 4
         } else {
-            (select_samples[next_sample_idx as usize].idx_in_l0_block() / size::BITS_PER_L2_BLOCK) as usize
+            select_samples[next_sample_idx as usize].block_idx_in_l0_block()
         }
     };
 


### PR DESCRIPTION
This should make the structure of the index clearer and means the different parts are separated out earlier in the process of building (and also more in the process of querying).

This also improves building of the select index to take some advantage of parallelism and to be O(n) in the number of bits rather than O(n log(n)) (as previously we would do separate log(n) queries for each sample). This is unfortunately more complicated code, but should mean the whole build index is O(n) now.

Resolves #7 , resolves #8.