### PR TITLE
Add support for iteration to Bits

### DIFF
--- a/indexed-bitvec-core/Cargo.toml
+++ b/indexed-bitvec-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "indexed_bitvec_core"
-version = "2.2.0"
+version = "3.0.0"
 edition = "2018"
 description = "Core operations on indexed bitvectors including (hopefully) fast rank and select operations."
 repository = "https://github.com/DarkOtter/indexed-bitvec-rs"

--- a/indexed-bitvec-core/src/bits.rs
+++ b/indexed-bitvec-core/src/bits.rs
@@ -323,6 +323,7 @@ impl<T: core::ops::Deref<Target = [u8]>> BitIndexIterator<T> {
                 None
             },
             Some(next_sub_idx) => {
+                debug_assert!(next_sub_idx >= byte_offset);
                 let res = byte_index_bits + next_sub_idx;
                 self.search_from = res + 1;
                 Some(res)
@@ -339,6 +340,7 @@ impl<T: core::ops::Deref<Target = [u8]>> Iterator for SetBitIndexIterator<T> {
 
     fn next(&mut self) -> Option<u64> {
         self.0.next(|remaining_part, byte_offset| {
+            debug_assert!(byte_offset < 8);
             let target_rank = must_have_or_bug(remaining_part.rank_ones(byte_offset));
             remaining_part.select_ones(target_rank)
         })
@@ -353,6 +355,7 @@ impl<T: core::ops::Deref<Target = [u8]>> Iterator for ZeroBitIndexIterator<T> {
 
     fn next(&mut self) -> Option<u64> {
         self.0.next(|remaining_part, byte_offset| {
+            debug_assert!(byte_offset < 8);
             let target_rank = must_have_or_bug(remaining_part.rank_zeros(byte_offset));
             remaining_part.select_zeros(target_rank)
         })

--- a/indexed-bitvec-core/src/bits.rs
+++ b/indexed-bitvec-core/src/bits.rs
@@ -582,12 +582,14 @@ mod tests {
     }
 
     quickcheck! {
-        fn fuzz_test_iter_positions(bits: Bits<Box<[u8]>>) -> () {
+        fn fuzz_test_iter(bits: Bits<Box<[u8]>>) -> () {
+            let as_bools: Vec<bool> =
+                (0..bits.used_bits()).map(|idx| bits.get(idx).unwrap()).collect();
             let ones_locs: Vec<u64> =
                 (0..bits.used_bits()).filter(|&idx| bits.get(idx).unwrap()).collect();
             let zeros_locs: Vec<u64> =
                 (0..bits.used_bits()).filter(|&idx| !(bits.get(idx).unwrap())).collect();
-
+            assert_eq!(as_bools, bits.iter().collect::<Vec<_>>());
             assert_eq!(ones_locs, bits.iter_set_bits().collect::<Vec<_>>());
             assert_eq!(zeros_locs, bits.iter_zero_bits().collect::<Vec<_>>());
         }

--- a/indexed-bitvec-core/src/index_raw.rs
+++ b/indexed-bitvec-core/src/index_raw.rs
@@ -20,9 +20,9 @@
 //! so you may run into panics from e.g. out of bounds accesses
 //! to slices. They should all be memory-safe though.
 
-use super::with_offset::WithOffset;
-use super::{ceil_div, ceil_div_u64};
-use super::Bits;
+use crate::with_offset::WithOffset;
+use crate::{ceil_div, ceil_div_u64};
+use crate::bits::Bits;
 use crate::ones_or_zeros::{OneBits, OnesOrZeros, ZeroBits};
 use core::cmp::min;
 

--- a/indexed-bitvec-core/src/lib.rs
+++ b/indexed-bitvec-core/src/lib.rs
@@ -69,8 +69,7 @@ mod word;
 
 mod bytes;
 
-mod bits;
-pub use crate::bits::Bits;
+pub mod bits;
 
 mod with_offset;
 

--- a/indexed-bitvec/Cargo.toml
+++ b/indexed-bitvec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "indexed_bitvec"
-version = "2.2.0"
+version = "2.3.0"
 edition = "2018"
 description = "An indexed bitvector with (hopefully) fast rank and select operations."
 repository = "https://github.com/DarkOtter/indexed-bitvec-rs"
@@ -16,7 +16,7 @@ implement_heapsize = ["heapsize", "indexed_bitvec_core/implement_heapsize"]
 
 [dependencies.indexed_bitvec_core]
 path = "../indexed-bitvec-core"
-version = "2.2"
+version = "3.0"
 
 [dependencies.heapsize]
 optional = true

--- a/indexed-bitvec/src/indexed_bits.rs
+++ b/indexed-bitvec/src/indexed_bits.rs
@@ -15,7 +15,8 @@
 */
 //! A bitvector with an index to allow fast rank and select.
 use std::ops::{Deref, DerefMut};
-use indexed_bitvec_core::*;
+use indexed_bitvec_core::bits::Bits;
+use indexed_bitvec_core::index_raw;
 
 /// Bits stored with extra index data for fast rank and select.
 #[derive(Clone, Debug)]

--- a/indexed-bitvec/src/lib.rs
+++ b/indexed-bitvec/src/lib.rs
@@ -21,7 +21,7 @@ extern crate indexed_bitvec_core;
 #[cfg(feature = "implement_heapsize")]
 extern crate heapsize;
 
-pub use indexed_bitvec_core::Bits;
+pub use indexed_bitvec_core::bits::Bits;
 
 mod indexed_bits;
 pub use crate::indexed_bits::IndexedBits;


### PR DESCRIPTION
This involves some breaking changes in what is exposed from indexed_bitvec_core, though only adds things to indexed_bitvec.